### PR TITLE
Crop labeled all the can images in left_cam, and added a python script to change path so that multiple users can crop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 spot_env/
+spot-sdk/

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0005.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0005.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0005.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0005.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>525</xmin>
+			<ymin>273</ymin>
+			<xmax>560</xmax>
+			<ymax>326</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0006.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0006.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0006.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0006.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>424</xmin>
+			<ymin>259</ymin>
+			<xmax>446</xmax>
+			<ymax>298</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0007.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0007.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0007.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0007.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>401</xmin>
+			<ymin>262</ymin>
+			<xmax>425</xmax>
+			<ymax>301</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0008.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0008.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0008.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0008.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>406</xmin>
+			<ymin>266</ymin>
+			<xmax>431</xmax>
+			<ymax>304</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0009.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0009.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0009.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0009.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>406</xmin>
+			<ymin>264</ymin>
+			<xmax>432</xmax>
+			<ymax>307</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0010.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0010.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0010.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0010.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>423</xmin>
+			<ymin>258</ymin>
+			<xmax>450</xmax>
+			<ymax>302</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0011.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0011.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0011.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0011.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>488</xmin>
+			<ymin>280</ymin>
+			<xmax>527</xmax>
+			<ymax>339</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0012.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0012.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0012.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0012.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>464</xmin>
+			<ymin>298</ymin>
+			<xmax>496</xmax>
+			<ymax>356</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0013.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0013.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0013.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0013.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>460</xmin>
+			<ymin>311</ymin>
+			<xmax>501</xmax>
+			<ymax>372</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0014.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0014.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0014.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0014.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>507</xmin>
+			<ymin>369</ymin>
+			<xmax>567</xmax>
+			<ymax>458</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0015.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0015.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0015.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0015.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>1</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>394</xmin>
+			<ymin>436</ymin>
+			<xmax>481</xmax>
+			<ymax>480</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0016.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0016.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0016.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0016.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>1</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>382</xmin>
+			<ymin>382</ymin>
+			<xmax>439</xmax>
+			<ymax>480</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0017.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0017.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0017.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0017.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>1</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>582</xmin>
+			<ymin>320</ymin>
+			<xmax>640</xmax>
+			<ymax>404</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0020.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0020.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0020.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0020.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>542</xmin>
+			<ymin>267</ymin>
+			<xmax>580</xmax>
+			<ymax>315</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0021.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0021.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0021.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0021.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>354</xmin>
+			<ymin>247</ymin>
+			<xmax>382</xmax>
+			<ymax>285</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0022.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0022.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0022.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0022.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>327</xmin>
+			<ymin>256</ymin>
+			<xmax>358</xmax>
+			<ymax>296</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0023.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0023.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0023.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0023.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>324</xmin>
+			<ymin>243</ymin>
+			<xmax>351</xmax>
+			<ymax>281</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0024.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0024.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0024.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0024.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>310</xmin>
+			<ymin>262</ymin>
+			<xmax>336</xmax>
+			<ymax>302</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0025.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0025.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0025.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0025.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>314</xmin>
+			<ymin>264</ymin>
+			<xmax>342</xmax>
+			<ymax>306</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0026.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0026.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0026.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0026.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>300</xmin>
+			<ymin>245</ymin>
+			<xmax>328</xmax>
+			<ymax>280</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0027.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0027.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0027.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0027.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>311</xmin>
+			<ymin>277</ymin>
+			<xmax>343</xmax>
+			<ymax>329</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0028.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0028.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0028.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0028.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>322</xmin>
+			<ymin>273</ymin>
+			<xmax>350</xmax>
+			<ymax>317</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0029.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0029.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0029.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0029.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>318</xmin>
+			<ymin>262</ymin>
+			<xmax>341</xmax>
+			<ymax>307</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0030.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0030.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0030.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0030.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>335</xmin>
+			<ymin>263</ymin>
+			<xmax>356</xmax>
+			<ymax>310</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0031.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0031.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0031.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0031.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>342</xmin>
+			<ymin>263</ymin>
+			<xmax>364</xmax>
+			<ymax>305</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0032.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0032.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0032.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0032.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>342</xmin>
+			<ymin>261</ymin>
+			<xmax>366</xmax>
+			<ymax>301</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0033.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0033.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0033.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0033.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>344</xmin>
+			<ymin>263</ymin>
+			<xmax>370</xmax>
+			<ymax>306</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0034.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0034.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0034.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0034.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>345</xmin>
+			<ymin>263</ymin>
+			<xmax>371</xmax>
+			<ymax>305</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0035.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0035.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0035.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0035.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>341</xmin>
+			<ymin>260</ymin>
+			<xmax>374</xmax>
+			<ymax>308</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0036.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0036.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0036.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0036.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>345</xmin>
+			<ymin>264</ymin>
+			<xmax>373</xmax>
+			<ymax>310</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0038.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0038.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0038.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0038.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>303</xmin>
+			<ymin>259</ymin>
+			<xmax>340</xmax>
+			<ymax>291</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0039.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0039.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0039.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0039.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>309</xmin>
+			<ymin>262</ymin>
+			<xmax>341</xmax>
+			<ymax>292</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0040.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0040.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0040.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0040.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>306</xmin>
+			<ymin>259</ymin>
+			<xmax>340</xmax>
+			<ymax>290</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0041.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0041.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0041.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0041.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>296</xmin>
+			<ymin>249</ymin>
+			<xmax>333</xmax>
+			<ymax>282</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0042.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0042.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0042.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0042.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>345</xmin>
+			<ymin>241</ymin>
+			<xmax>375</xmax>
+			<ymax>267</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0043.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0043.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0043.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0043.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>341</xmin>
+			<ymin>241</ymin>
+			<xmax>373</xmax>
+			<ymax>271</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0044.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0044.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0044.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0044.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>331</xmin>
+			<ymin>255</ymin>
+			<xmax>367</xmax>
+			<ymax>283</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0045.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0045.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0045.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0045.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>335</xmin>
+			<ymin>255</ymin>
+			<xmax>368</xmax>
+			<ymax>282</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0046.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0046.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0046.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0046.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>340</xmin>
+			<ymin>252</ymin>
+			<xmax>370</xmax>
+			<ymax>281</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0047.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0047.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0047.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0047.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>340</xmin>
+			<ymin>253</ymin>
+			<xmax>371</xmax>
+			<ymax>283</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0048.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0048.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0048.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0048.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>340</xmin>
+			<ymin>253</ymin>
+			<xmax>371</xmax>
+			<ymax>280</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0049.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0049.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0049.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0049.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>338</xmin>
+			<ymin>253</ymin>
+			<xmax>369</xmax>
+			<ymax>284</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0050.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0050.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0050.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0050.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>345</xmin>
+			<ymin>247</ymin>
+			<xmax>375</xmax>
+			<ymax>279</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0051.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0051.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0051.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0051.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>383</xmin>
+			<ymin>256</ymin>
+			<xmax>421</xmax>
+			<ymax>283</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0052.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0052.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0052.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0052.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>390</xmin>
+			<ymin>257</ymin>
+			<xmax>423</xmax>
+			<ymax>287</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0053.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0053.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0053.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0053.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>461</xmin>
+			<ymin>259</ymin>
+			<xmax>500</xmax>
+			<ymax>291</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0054.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0054.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0054.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0054.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>394</xmin>
+			<ymin>247</ymin>
+			<xmax>433</xmax>
+			<ymax>273</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0055.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0055.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0055.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0055.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>367</xmin>
+			<ymin>244</ymin>
+			<xmax>404</xmax>
+			<ymax>266</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0056.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0056.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0056.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0056.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>362</xmin>
+			<ymin>244</ymin>
+			<xmax>393</xmax>
+			<ymax>263</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0057.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0057.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0057.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0057.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>321</xmin>
+			<ymin>238</ymin>
+			<xmax>355</xmax>
+			<ymax>257</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0058.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0058.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0058.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0058.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>279</xmin>
+			<ymin>242</ymin>
+			<xmax>311</xmax>
+			<ymax>265</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0059.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0059.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0059.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0059.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>272</xmin>
+			<ymin>241</ymin>
+			<xmax>306</xmax>
+			<ymax>265</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0060.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0060.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0060.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0060.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>246</xmin>
+			<ymin>245</ymin>
+			<xmax>281</xmax>
+			<ymax>270</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0061.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0061.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0061.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0061.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>224</xmin>
+			<ymin>266</ymin>
+			<xmax>264</xmax>
+			<ymax>295</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0062.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0062.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0062.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0062.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>227</xmin>
+			<ymin>262</ymin>
+			<xmax>268</xmax>
+			<ymax>287</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0063.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0063.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0063.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0063.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>252</xmin>
+			<ymin>253</ymin>
+			<xmax>292</xmax>
+			<ymax>277</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0064.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0064.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0064.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0064.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>228</xmin>
+			<ymin>271</ymin>
+			<xmax>268</xmax>
+			<ymax>301</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0065.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0065.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0065.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0065.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>181</xmin>
+			<ymin>295</ymin>
+			<xmax>235</xmax>
+			<ymax>332</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0066.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0066.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0066.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0066.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>251</xmin>
+			<ymin>299</ymin>
+			<xmax>302</xmax>
+			<ymax>337</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0067.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0067.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0067.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0067.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>233</xmin>
+			<ymin>314</ymin>
+			<xmax>291</xmax>
+			<ymax>360</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0068.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0068.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0068.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0068.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>332</xmin>
+			<ymin>329</ymin>
+			<xmax>389</xmax>
+			<ymax>384</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0069.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0069.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0069.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0069.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>435</xmin>
+			<ymin>314</ymin>
+			<xmax>481</xmax>
+			<ymax>360</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0070.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0070.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0070.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0070.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>432</xmin>
+			<ymin>265</ymin>
+			<xmax>465</xmax>
+			<ymax>307</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0071.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0071.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0071.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0071.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>454</xmin>
+			<ymin>277</ymin>
+			<xmax>479</xmax>
+			<ymax>321</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0072.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0072.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0072.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0072.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>476</xmin>
+			<ymin>294</ymin>
+			<xmax>510</xmax>
+			<ymax>346</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0073.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0073.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0073.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0073.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>486</xmin>
+			<ymin>302</ymin>
+			<xmax>522</xmax>
+			<ymax>358</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0074.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0074.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0074.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0074.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>483</xmin>
+			<ymin>306</ymin>
+			<xmax>519</xmax>
+			<ymax>363</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0075.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0075.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0075.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0075.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>480</xmin>
+			<ymin>309</ymin>
+			<xmax>520</xmax>
+			<ymax>362</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0076.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0076.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0076.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0076.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>437</xmin>
+			<ymin>306</ymin>
+			<xmax>471</xmax>
+			<ymax>362</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0077.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0077.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0077.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0077.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>378</xmin>
+			<ymin>313</ymin>
+			<xmax>416</xmax>
+			<ymax>379</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0078.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0078.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0078.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0078.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>337</xmin>
+			<ymin>307</ymin>
+			<xmax>378</xmax>
+			<ymax>351</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0079.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0079.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0079.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0079.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>311</xmin>
+			<ymin>318</ymin>
+			<xmax>366</xmax>
+			<ymax>366</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0080.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0080.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0080.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0080.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>187</xmin>
+			<ymin>335</ymin>
+			<xmax>261</xmax>
+			<ymax>387</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0081.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0081.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0081.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0081.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>271</xmin>
+			<ymin>302</ymin>
+			<xmax>331</xmax>
+			<ymax>339</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0082.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0082.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0082.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0082.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>233</xmin>
+			<ymin>289</ymin>
+			<xmax>281</xmax>
+			<ymax>331</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0083.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0083.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0083.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0083.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>241</xmin>
+			<ymin>283</ymin>
+			<xmax>290</xmax>
+			<ymax>319</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0084.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0084.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0084.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0084.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>261</xmin>
+			<ymin>272</ymin>
+			<xmax>310</xmax>
+			<ymax>299</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0085.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0085.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0085.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0085.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>186</xmin>
+			<ymin>278</ymin>
+			<xmax>242</xmax>
+			<ymax>304</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0086.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0086.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0086.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0086.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>185</xmin>
+			<ymin>254</ymin>
+			<xmax>227</xmax>
+			<ymax>274</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0087.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0087.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0087.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0087.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>264</xmin>
+			<ymin>240</ymin>
+			<xmax>300</xmax>
+			<ymax>262</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0088.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0088.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0088.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0088.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>327</xmin>
+			<ymin>229</ymin>
+			<xmax>360</xmax>
+			<ymax>259</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0089.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0089.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0089.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0089.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>314</xmin>
+			<ymin>238</ymin>
+			<xmax>348</xmax>
+			<ymax>264</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0090.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0090.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0090.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0090.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>373</xmin>
+			<ymin>229</ymin>
+			<xmax>396</xmax>
+			<ymax>254</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0091.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0091.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0091.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0091.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>386</xmin>
+			<ymin>240</ymin>
+			<xmax>409</xmax>
+			<ymax>265</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0092.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0092.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0092.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0092.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>383</xmin>
+			<ymin>244</ymin>
+			<xmax>408</xmax>
+			<ymax>269</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0093.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0093.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0093.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0093.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>385</xmin>
+			<ymin>242</ymin>
+			<xmax>410</xmax>
+			<ymax>266</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0094.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0094.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0094.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0094.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>376</xmin>
+			<ymin>252</ymin>
+			<xmax>407</xmax>
+			<ymax>275</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0095.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0095.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0095.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0095.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>325</xmin>
+			<ymin>249</ymin>
+			<xmax>352</xmax>
+			<ymax>275</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0096.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0096.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0096.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0096.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>375</xmin>
+			<ymin>255</ymin>
+			<xmax>406</xmax>
+			<ymax>283</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0097.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0097.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0097.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0097.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>387</xmin>
+			<ymin>271</ymin>
+			<xmax>426</xmax>
+			<ymax>302</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0098.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0098.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0098.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0098.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>365</xmin>
+			<ymin>260</ymin>
+			<xmax>404</xmax>
+			<ymax>287</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0099.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0099.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0099.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0099.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>420</xmin>
+			<ymin>272</ymin>
+			<xmax>463</xmax>
+			<ymax>300</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0100.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0100.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0100.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0100.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>441</xmin>
+			<ymin>290</ymin>
+			<xmax>498</xmax>
+			<ymax>323</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0101.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0101.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0101.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0101.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>391</xmin>
+			<ymin>295</ymin>
+			<xmax>445</xmax>
+			<ymax>330</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0102.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0102.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0102.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0102.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>318</xmin>
+			<ymin>286</ymin>
+			<xmax>371</xmax>
+			<ymax>320</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0103.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0103.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0103.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0103.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>333</xmin>
+			<ymin>289</ymin>
+			<xmax>380</xmax>
+			<ymax>325</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0104.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0104.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0104.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0104.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>346</xmin>
+			<ymin>287</ymin>
+			<xmax>395</xmax>
+			<ymax>323</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0105.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0105.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0105.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0105.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>306</xmin>
+			<ymin>288</ymin>
+			<xmax>348</xmax>
+			<ymax>325</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0106.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0106.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0106.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0106.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>363</xmin>
+			<ymin>288</ymin>
+			<xmax>411</xmax>
+			<ymax>326</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0107.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0107.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0107.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0107.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>305</xmin>
+			<ymin>289</ymin>
+			<xmax>343</xmax>
+			<ymax>331</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0108.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0108.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0108.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0108.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>407</xmin>
+			<ymin>312</ymin>
+			<xmax>446</xmax>
+			<ymax>357</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0109.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0109.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0109.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0109.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>346</xmin>
+			<ymin>319</ymin>
+			<xmax>395</xmax>
+			<ymax>370</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0110.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0110.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0110.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0110.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>307</xmin>
+			<ymin>318</ymin>
+			<xmax>362</xmax>
+			<ymax>362</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0111.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0111.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0111.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0111.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>222</xmin>
+			<ymin>317</ymin>
+			<xmax>290</xmax>
+			<ymax>355</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0112.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0112.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0112.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0112.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>228</xmin>
+			<ymin>286</ymin>
+			<xmax>277</xmax>
+			<ymax>311</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0113.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0113.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0113.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0113.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>266</xmin>
+			<ymin>284</ymin>
+			<xmax>313</xmax>
+			<ymax>307</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0114.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0114.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0114.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0114.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>279</xmin>
+			<ymin>274</ymin>
+			<xmax>328</xmax>
+			<ymax>301</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0115.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0115.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0115.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0115.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>293</xmin>
+			<ymin>280</ymin>
+			<xmax>342</xmax>
+			<ymax>307</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0116.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0116.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0116.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0116.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>290</xmin>
+			<ymin>277</ymin>
+			<xmax>333</xmax>
+			<ymax>301</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0117.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0117.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0117.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0117.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>184</xmin>
+			<ymin>290</ymin>
+			<xmax>237</xmax>
+			<ymax>319</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0118.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0118.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0118.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0118.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>123</xmin>
+			<ymin>293</ymin>
+			<xmax>185</xmax>
+			<ymax>323</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0119.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0119.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0119.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0119.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>134</xmin>
+			<ymin>252</ymin>
+			<xmax>176</xmax>
+			<ymax>277</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0120.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0120.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0120.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0120.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>214</xmin>
+			<ymin>246</ymin>
+			<xmax>247</xmax>
+			<ymax>273</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0121.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0121.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0121.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0121.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>252</xmin>
+			<ymin>229</ymin>
+			<xmax>289</xmax>
+			<ymax>254</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0122.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0122.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0122.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0122.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>235</xmin>
+			<ymin>241</ymin>
+			<xmax>270</xmax>
+			<ymax>267</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0123.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0123.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0123.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0123.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>244</xmin>
+			<ymin>244</ymin>
+			<xmax>270</xmax>
+			<ymax>268</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0124.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0124.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0124.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0124.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>276</xmin>
+			<ymin>237</ymin>
+			<xmax>303</xmax>
+			<ymax>268</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0125.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0125.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0125.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0125.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>393</xmin>
+			<ymin>248</ymin>
+			<xmax>440</xmax>
+			<ymax>277</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0126.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0126.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0126.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0126.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>435</xmin>
+			<ymin>248</ymin>
+			<xmax>474</xmax>
+			<ymax>285</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0127.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0127.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0127.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0127.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>351</xmin>
+			<ymin>255</ymin>
+			<xmax>386</xmax>
+			<ymax>288</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0128.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0128.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0128.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0128.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>349</xmin>
+			<ymin>255</ymin>
+			<xmax>376</xmax>
+			<ymax>287</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0129.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0129.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0129.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0129.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>333</xmin>
+			<ymin>253</ymin>
+			<xmax>355</xmax>
+			<ymax>285</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0130.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0130.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0130.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0130.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>337</xmin>
+			<ymin>254</ymin>
+			<xmax>353</xmax>
+			<ymax>283</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0131.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0131.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0131.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0131.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>334</xmin>
+			<ymin>252</ymin>
+			<xmax>353</xmax>
+			<ymax>284</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0132.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0132.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0132.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0132.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>337</xmin>
+			<ymin>253</ymin>
+			<xmax>363</xmax>
+			<ymax>283</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0133.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0133.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0133.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0133.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>343</xmin>
+			<ymin>249</ymin>
+			<xmax>369</xmax>
+			<ymax>276</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0134.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0134.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0134.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0134.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>332</xmin>
+			<ymin>254</ymin>
+			<xmax>356</xmax>
+			<ymax>287</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0135.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0135.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0135.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0135.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>316</xmin>
+			<ymin>267</ymin>
+			<xmax>337</xmax>
+			<ymax>302</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0136.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0136.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0136.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0136.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>321</xmin>
+			<ymin>240</ymin>
+			<xmax>351</xmax>
+			<ymax>268</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0137.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0137.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0137.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0137.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>395</xmin>
+			<ymin>243</ymin>
+			<xmax>422</xmax>
+			<ymax>270</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0138.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0138.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0138.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0138.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>403</xmin>
+			<ymin>248</ymin>
+			<xmax>429</xmax>
+			<ymax>278</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0139.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0139.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0139.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0139.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>405</xmin>
+			<ymin>251</ymin>
+			<xmax>430</xmax>
+			<ymax>278</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0140.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0140.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0140.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0140.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>394</xmin>
+			<ymin>248</ymin>
+			<xmax>420</xmax>
+			<ymax>279</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0141.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0141.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0141.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0141.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>387</xmin>
+			<ymin>249</ymin>
+			<xmax>419</xmax>
+			<ymax>273</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0142.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0142.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0142.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0142.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>382</xmin>
+			<ymin>245</ymin>
+			<xmax>404</xmax>
+			<ymax>273</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0143.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0143.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0143.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0143.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>460</xmin>
+			<ymin>249</ymin>
+			<xmax>502</xmax>
+			<ymax>276</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0144.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0144.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0144.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0144.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>430</xmin>
+			<ymin>255</ymin>
+			<xmax>471</xmax>
+			<ymax>286</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0145.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0145.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0145.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0145.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>520</xmin>
+			<ymin>271</ymin>
+			<xmax>567</xmax>
+			<ymax>298</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0146.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0146.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0146.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0146.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>459</xmin>
+			<ymin>267</ymin>
+			<xmax>503</xmax>
+			<ymax>296</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0147.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0147.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0147.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0147.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>417</xmin>
+			<ymin>260</ymin>
+			<xmax>461</xmax>
+			<ymax>287</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0148.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0148.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0148.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0148.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>424</xmin>
+			<ymin>263</ymin>
+			<xmax>461</xmax>
+			<ymax>287</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0149.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0149.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0149.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0149.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>380</xmin>
+			<ymin>260</ymin>
+			<xmax>415</xmax>
+			<ymax>281</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0150.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0150.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0150.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0150.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>336</xmin>
+			<ymin>256</ymin>
+			<xmax>373</xmax>
+			<ymax>285</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0151.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0151.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0151.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0151.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>320</xmin>
+			<ymin>254</ymin>
+			<xmax>362</xmax>
+			<ymax>281</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0152.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0152.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0152.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0152.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>371</xmin>
+			<ymin>256</ymin>
+			<xmax>408</xmax>
+			<ymax>283</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0153.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0153.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0153.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0153.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>373</xmin>
+			<ymin>259</ymin>
+			<xmax>412</xmax>
+			<ymax>286</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0154.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0154.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0154.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0154.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>373</xmin>
+			<ymin>255</ymin>
+			<xmax>406</xmax>
+			<ymax>281</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0157.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0157.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0157.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0157.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>379</xmin>
+			<ymin>265</ymin>
+			<xmax>414</xmax>
+			<ymax>292</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0158.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0158.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0158.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0158.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>350</xmin>
+			<ymin>249</ymin>
+			<xmax>379</xmax>
+			<ymax>277</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0159.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0159.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0159.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0159.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>325</xmin>
+			<ymin>241</ymin>
+			<xmax>355</xmax>
+			<ymax>272</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0160.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0160.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0160.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0160.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>330</xmin>
+			<ymin>241</ymin>
+			<xmax>359</xmax>
+			<ymax>267</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0161.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0161.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0161.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0161.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>324</xmin>
+			<ymin>246</ymin>
+			<xmax>357</xmax>
+			<ymax>272</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0162.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0162.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0162.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0162.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>343</xmin>
+			<ymin>238</ymin>
+			<xmax>372</xmax>
+			<ymax>272</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0163.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0163.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0163.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0163.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>345</xmin>
+			<ymin>245</ymin>
+			<xmax>376</xmax>
+			<ymax>271</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0164.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0164.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0164.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0164.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>443</xmin>
+			<ymin>247</ymin>
+			<xmax>485</xmax>
+			<ymax>273</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0165.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0165.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0165.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0165.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>1</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>617</xmin>
+			<ymin>281</ymin>
+			<xmax>640</xmax>
+			<ymax>316</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0166.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0166.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0166.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0166.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>501</xmin>
+			<ymin>277</ymin>
+			<xmax>555</xmax>
+			<ymax>309</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0168.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0168.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0168.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0168.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>532</xmin>
+			<ymin>309</ymin>
+			<xmax>597</xmax>
+			<ymax>351</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0169.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0169.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0169.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0169.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>410</xmin>
+			<ymin>320</ymin>
+			<xmax>471</xmax>
+			<ymax>360</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0170.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0170.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0170.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0170.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>330</xmin>
+			<ymin>331</ymin>
+			<xmax>385</xmax>
+			<ymax>367</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0171.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0171.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0171.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0171.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>274</xmin>
+			<ymin>332</ymin>
+			<xmax>333</xmax>
+			<ymax>376</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0172.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0172.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0172.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0172.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>200</xmin>
+			<ymin>323</ymin>
+			<xmax>261</xmax>
+			<ymax>360</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0173.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0173.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0173.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0173.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>346</xmin>
+			<ymin>290</ymin>
+			<xmax>401</xmax>
+			<ymax>333</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0174.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0174.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0174.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0174.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>432</xmin>
+			<ymin>296</ymin>
+			<xmax>491</xmax>
+			<ymax>340</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0175.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0175.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0175.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0175.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>291</xmin>
+			<ymin>292</ymin>
+			<xmax>315</xmax>
+			<ymax>341</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0176.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0176.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0176.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0176.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>402</xmin>
+			<ymin>316</ymin>
+			<xmax>438</xmax>
+			<ymax>367</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0177.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0177.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0177.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0177.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>354</xmin>
+			<ymin>312</ymin>
+			<xmax>392</xmax>
+			<ymax>367</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0178.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0178.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0178.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0178.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>292</xmin>
+			<ymin>298</ymin>
+			<xmax>331</xmax>
+			<ymax>358</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0179.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0179.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0179.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0179.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>322</xmin>
+			<ymin>287</ymin>
+			<xmax>373</xmax>
+			<ymax>329</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0180.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0180.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0180.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0180.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>311</xmin>
+			<ymin>317</ymin>
+			<xmax>364</xmax>
+			<ymax>359</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0181.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0181.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0181.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0181.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>317</xmin>
+			<ymin>310</ymin>
+			<xmax>366</xmax>
+			<ymax>356</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0182.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0182.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0182.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0182.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>357</xmin>
+			<ymin>331</ymin>
+			<xmax>406</xmax>
+			<ymax>389</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0183.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0183.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0183.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0183.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>346</xmin>
+			<ymin>295</ymin>
+			<xmax>389</xmax>
+			<ymax>329</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0184.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0184.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0184.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0184.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>285</xmin>
+			<ymin>292</ymin>
+			<xmax>337</xmax>
+			<ymax>324</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0185.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0185.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0185.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0185.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>268</xmin>
+			<ymin>299</ymin>
+			<xmax>334</xmax>
+			<ymax>330</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0186.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0186.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0186.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0186.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>217</xmin>
+			<ymin>274</ymin>
+			<xmax>261</xmax>
+			<ymax>298</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0187.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0187.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0187.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0187.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>278</xmin>
+			<ymin>254</ymin>
+			<xmax>313</xmax>
+			<ymax>282</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0188.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0188.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0188.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0188.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>288</xmin>
+			<ymin>247</ymin>
+			<xmax>321</xmax>
+			<ymax>274</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0189.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0189.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0189.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0189.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>327</xmin>
+			<ymin>247</ymin>
+			<xmax>360</xmax>
+			<ymax>278</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0190.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0190.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0190.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0190.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>315</xmin>
+			<ymin>252</ymin>
+			<xmax>356</xmax>
+			<ymax>279</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0191.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0191.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0191.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0191.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>296</xmin>
+			<ymin>259</ymin>
+			<xmax>322</xmax>
+			<ymax>281</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0192.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0192.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0192.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0192.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>299</xmin>
+			<ymin>242</ymin>
+			<xmax>342</xmax>
+			<ymax>276</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0193.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0193.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0193.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0193.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>307</xmin>
+			<ymin>258</ymin>
+			<xmax>345</xmax>
+			<ymax>293</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0194.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0194.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0194.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0194.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>291</xmin>
+			<ymin>252</ymin>
+			<xmax>326</xmax>
+			<ymax>281</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0195.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0195.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0195.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0195.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>341</xmin>
+			<ymin>244</ymin>
+			<xmax>374</xmax>
+			<ymax>267</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0196.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0196.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0196.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0196.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>346</xmin>
+			<ymin>240</ymin>
+			<xmax>371</xmax>
+			<ymax>268</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0197.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0197.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0197.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0197.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>328</xmin>
+			<ymin>245</ymin>
+			<xmax>355</xmax>
+			<ymax>268</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0198.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0198.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0198.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0198.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>375</xmin>
+			<ymin>241</ymin>
+			<xmax>412</xmax>
+			<ymax>266</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0199.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0199.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0199.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0199.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>355</xmin>
+			<ymin>236</ymin>
+			<xmax>385</xmax>
+			<ymax>259</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0200.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0200.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0200.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0200.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>375</xmin>
+			<ymin>241</ymin>
+			<xmax>410</xmax>
+			<ymax>267</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0201.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0201.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0201.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0201.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>404</xmin>
+			<ymin>251</ymin>
+			<xmax>445</xmax>
+			<ymax>276</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0202.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0202.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0202.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0202.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>479</xmin>
+			<ymin>256</ymin>
+			<xmax>523</xmax>
+			<ymax>287</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0203.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0203.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0203.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0203.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>461</xmin>
+			<ymin>254</ymin>
+			<xmax>511</xmax>
+			<ymax>278</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0204.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0204.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0204.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0204.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>445</xmin>
+			<ymin>252</ymin>
+			<xmax>489</xmax>
+			<ymax>277</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0205.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0205.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0205.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0205.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>441</xmin>
+			<ymin>249</ymin>
+			<xmax>483</xmax>
+			<ymax>277</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0206.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0206.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0206.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0206.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>424</xmin>
+			<ymin>245</ymin>
+			<xmax>470</xmax>
+			<ymax>267</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0207.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0207.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0207.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0207.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>422</xmin>
+			<ymin>244</ymin>
+			<xmax>456</xmax>
+			<ymax>263</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0208.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0208.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0208.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0208.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>442</xmin>
+			<ymin>252</ymin>
+			<xmax>479</xmax>
+			<ymax>274</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0209.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0209.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0209.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0209.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>431</xmin>
+			<ymin>263</ymin>
+			<xmax>476</xmax>
+			<ymax>286</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0210.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0210.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0210.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0210.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>430</xmin>
+			<ymin>273</ymin>
+			<xmax>470</xmax>
+			<ymax>298</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0212.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0212.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0212.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0212.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>373</xmin>
+			<ymin>285</ymin>
+			<xmax>424</xmax>
+			<ymax>315</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0213.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0213.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0213.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0213.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>369</xmin>
+			<ymin>288</ymin>
+			<xmax>411</xmax>
+			<ymax>319</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0214.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0214.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0214.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0214.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>343</xmin>
+			<ymin>291</ymin>
+			<xmax>398</xmax>
+			<ymax>317</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0217.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0217.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0217.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0217.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>336</xmin>
+			<ymin>292</ymin>
+			<xmax>380</xmax>
+			<ymax>317</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0218.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0218.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0218.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0218.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>336</xmin>
+			<ymin>293</ymin>
+			<xmax>378</xmax>
+			<ymax>321</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0219.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0219.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0219.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0219.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>337</xmin>
+			<ymin>297</ymin>
+			<xmax>374</xmax>
+			<ymax>319</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0220.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0220.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0220.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0220.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>313</xmin>
+			<ymin>294</ymin>
+			<xmax>359</xmax>
+			<ymax>322</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0221.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0221.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0221.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0221.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>281</xmin>
+			<ymin>288</ymin>
+			<xmax>323</xmax>
+			<ymax>317</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0222.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0222.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0222.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0222.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>267</xmin>
+			<ymin>297</ymin>
+			<xmax>320</xmax>
+			<ymax>325</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0223.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0223.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0223.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0223.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>277</xmin>
+			<ymin>285</ymin>
+			<xmax>321</xmax>
+			<ymax>309</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0224.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0224.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0224.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0224.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>244</xmin>
+			<ymin>277</ymin>
+			<xmax>289</xmax>
+			<ymax>305</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0225.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0225.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0225.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0225.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>250</xmin>
+			<ymin>270</ymin>
+			<xmax>292</xmax>
+			<ymax>300</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0226.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0226.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0226.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0226.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>255</xmin>
+			<ymin>272</ymin>
+			<xmax>284</xmax>
+			<ymax>301</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0228.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0228.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0228.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0228.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>215</xmin>
+			<ymin>277</ymin>
+			<xmax>254</xmax>
+			<ymax>302</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0229.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0229.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0229.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0229.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>251</xmin>
+			<ymin>273</ymin>
+			<xmax>295</xmax>
+			<ymax>300</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0230.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0230.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0230.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0230.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>304</xmin>
+			<ymin>270</ymin>
+			<xmax>346</xmax>
+			<ymax>300</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0231.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0231.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0231.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0231.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>268</xmin>
+			<ymin>261</ymin>
+			<xmax>302</xmax>
+			<ymax>285</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0232.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0232.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0232.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0232.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>225</xmin>
+			<ymin>266</ymin>
+			<xmax>263</xmax>
+			<ymax>295</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0233.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0233.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0233.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0233.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>192</xmin>
+			<ymin>270</ymin>
+			<xmax>240</xmax>
+			<ymax>294</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0234.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0234.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0234.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0234.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>244</xmin>
+			<ymin>274</ymin>
+			<xmax>288</xmax>
+			<ymax>298</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0235.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0235.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0235.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0235.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>421</xmin>
+			<ymin>281</ymin>
+			<xmax>471</xmax>
+			<ymax>310</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0236.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0236.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0236.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0236.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>385</xmin>
+			<ymin>288</ymin>
+			<xmax>435</xmax>
+			<ymax>319</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0237.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0237.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0237.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0237.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>269</xmin>
+			<ymin>274</ymin>
+			<xmax>318</xmax>
+			<ymax>307</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0238.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0238.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0238.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0238.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>244</xmin>
+			<ymin>275</ymin>
+			<xmax>291</xmax>
+			<ymax>302</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0239.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0239.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0239.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0239.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>286</xmin>
+			<ymin>273</ymin>
+			<xmax>328</xmax>
+			<ymax>304</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0240.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0240.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0240.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0240.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>278</xmin>
+			<ymin>271</ymin>
+			<xmax>321</xmax>
+			<ymax>297</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0241.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0241.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0241.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0241.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>314</xmin>
+			<ymin>308</ymin>
+			<xmax>362</xmax>
+			<ymax>338</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0242.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0242.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0242.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0242.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>322</xmin>
+			<ymin>314</ymin>
+			<xmax>369</xmax>
+			<ymax>336</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0243.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0243.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0243.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0243.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>373</xmin>
+			<ymin>296</ymin>
+			<xmax>422</xmax>
+			<ymax>325</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0244.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0244.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0244.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0244.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>443</xmin>
+			<ymin>288</ymin>
+			<xmax>496</xmax>
+			<ymax>318</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0245.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0245.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0245.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0245.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>432</xmin>
+			<ymin>284</ymin>
+			<xmax>491</xmax>
+			<ymax>309</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0246.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0246.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0246.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0246.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>489</xmin>
+			<ymin>298</ymin>
+			<xmax>558</xmax>
+			<ymax>334</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0250.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0250.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0250.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0250.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>517</xmin>
+			<ymin>306</ymin>
+			<xmax>586</xmax>
+			<ymax>343</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0251.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0251.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0251.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0251.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>458</xmin>
+			<ymin>292</ymin>
+			<xmax>523</xmax>
+			<ymax>323</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0252.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0252.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0252.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0252.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>529</xmin>
+			<ymin>322</ymin>
+			<xmax>604</xmax>
+			<ymax>366</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0253.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0253.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0253.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0253.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>471</xmin>
+			<ymin>339</ymin>
+			<xmax>550</xmax>
+			<ymax>403</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0254.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0254.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0254.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0254.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>519</xmin>
+			<ymin>387</ymin>
+			<xmax>626</xmax>
+			<ymax>479</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0255.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0255.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0255.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0255.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>347</xmin>
+			<ymin>369</ymin>
+			<xmax>423</xmax>
+			<ymax>438</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0256.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0256.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0256.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0256.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>285</xmin>
+			<ymin>378</ymin>
+			<xmax>344</xmax>
+			<ymax>462</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0257.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0257.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0257.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0257.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>106</xmin>
+			<ymin>356</ymin>
+			<xmax>179</xmax>
+			<ymax>450</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0258.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0258.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0258.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0258.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>213</xmin>
+			<ymin>315</ymin>
+			<xmax>276</xmax>
+			<ymax>369</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0259.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0259.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0259.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0259.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>299</xmin>
+			<ymin>287</ymin>
+			<xmax>360</xmax>
+			<ymax>318</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0260.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0260.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0260.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0260.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>292</xmin>
+			<ymin>272</ymin>
+			<xmax>340</xmax>
+			<ymax>303</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0261.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0261.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0261.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0261.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>383</xmin>
+			<ymin>283</ymin>
+			<xmax>439</xmax>
+			<ymax>313</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0263.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0263.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0263.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0263.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>392</xmin>
+			<ymin>280</ymin>
+			<xmax>430</xmax>
+			<ymax>323</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0264.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0264.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0264.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0264.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>308</xmin>
+			<ymin>280</ymin>
+			<xmax>354</xmax>
+			<ymax>326</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0265.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0265.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0265.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0265.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>234</xmin>
+			<ymin>292</ymin>
+			<xmax>277</xmax>
+			<ymax>344</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0266.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0266.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0266.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0266.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>225</xmin>
+			<ymin>290</ymin>
+			<xmax>266</xmax>
+			<ymax>343</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0267.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0267.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0267.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0267.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>221</xmin>
+			<ymin>286</ymin>
+			<xmax>256</xmax>
+			<ymax>335</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0268.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0268.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0268.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0268.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>214</xmin>
+			<ymin>271</ymin>
+			<xmax>253</xmax>
+			<ymax>319</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0269.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0269.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0269.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0269.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>206</xmin>
+			<ymin>273</ymin>
+			<xmax>246</xmax>
+			<ymax>323</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0270.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0270.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0270.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0270.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>210</xmin>
+			<ymin>271</ymin>
+			<xmax>248</xmax>
+			<ymax>317</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0271.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0271.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0271.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0271.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>265</xmin>
+			<ymin>262</ymin>
+			<xmax>302</xmax>
+			<ymax>308</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0272.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0272.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0272.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0272.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>303</xmin>
+			<ymin>259</ymin>
+			<xmax>331</xmax>
+			<ymax>301</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0273.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0273.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0273.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0273.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>301</xmin>
+			<ymin>260</ymin>
+			<xmax>332</xmax>
+			<ymax>297</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0274.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0274.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0274.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0274.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>289</xmin>
+			<ymin>254</ymin>
+			<xmax>317</xmax>
+			<ymax>291</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0275.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0275.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0275.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0275.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>253</xmin>
+			<ymin>248</ymin>
+			<xmax>287</xmax>
+			<ymax>292</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0276.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0276.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0276.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0276.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>316</xmin>
+			<ymin>247</ymin>
+			<xmax>342</xmax>
+			<ymax>284</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0277.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0277.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0277.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0277.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>403</xmin>
+			<ymin>250</ymin>
+			<xmax>437</xmax>
+			<ymax>287</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0278.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0278.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0278.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0278.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>424</xmin>
+			<ymin>256</ymin>
+			<xmax>452</xmax>
+			<ymax>294</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0279.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0279.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0279.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0279.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>354</xmin>
+			<ymin>251</ymin>
+			<xmax>388</xmax>
+			<ymax>284</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0280.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0280.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0280.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0280.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>375</xmin>
+			<ymin>246</ymin>
+			<xmax>402</xmax>
+			<ymax>280</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0281.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0281.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0281.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0281.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>340</xmin>
+			<ymin>248</ymin>
+			<xmax>370</xmax>
+			<ymax>282</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0282.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0282.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0282.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0282.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>290</xmin>
+			<ymin>245</ymin>
+			<xmax>314</xmax>
+			<ymax>282</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0283.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0283.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0283.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0283.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>355</xmin>
+			<ymin>239</ymin>
+			<xmax>379</xmax>
+			<ymax>274</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0284.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0284.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0284.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0284.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>333</xmin>
+			<ymin>252</ymin>
+			<xmax>357</xmax>
+			<ymax>295</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0285.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0285.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0285.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0285.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>370</xmin>
+			<ymin>246</ymin>
+			<xmax>397</xmax>
+			<ymax>291</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0286.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0286.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0286.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0286.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>357</xmin>
+			<ymin>248</ymin>
+			<xmax>386</xmax>
+			<ymax>287</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0287.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0287.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0287.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0287.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>356</xmin>
+			<ymin>244</ymin>
+			<xmax>383</xmax>
+			<ymax>280</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0288.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0288.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0288.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0288.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>353</xmin>
+			<ymin>242</ymin>
+			<xmax>380</xmax>
+			<ymax>281</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0289.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0289.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0289.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0289.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>358</xmin>
+			<ymin>242</ymin>
+			<xmax>382</xmax>
+			<ymax>281</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0290.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0290.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0290.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0290.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>341</xmin>
+			<ymin>234</ymin>
+			<xmax>365</xmax>
+			<ymax>276</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0291.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0291.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0291.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0291.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>388</xmin>
+			<ymin>243</ymin>
+			<xmax>410</xmax>
+			<ymax>279</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0292.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0292.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0292.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0292.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>328</xmin>
+			<ymin>251</ymin>
+			<xmax>359</xmax>
+			<ymax>295</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0293.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0293.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0293.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0293.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>345</xmin>
+			<ymin>253</ymin>
+			<xmax>369</xmax>
+			<ymax>293</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0294.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0294.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0294.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0294.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>354</xmin>
+			<ymin>256</ymin>
+			<xmax>380</xmax>
+			<ymax>295</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0295.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0295.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0295.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0295.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>364</xmin>
+			<ymin>248</ymin>
+			<xmax>390</xmax>
+			<ymax>289</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/can/annotations/left_cam/left_fisheye_image_0296.xml
+++ b/fetch/can/annotations/left_cam/left_fisheye_image_0296.xml
@@ -1,0 +1,26 @@
+<annotation>
+	<folder>left_cam</folder>
+	<filename>left_fisheye_image_0296.jpg</filename>
+	<path>path\to\folder\left_fisheye_image_0296.jpg</path>
+	<source>
+		<database>Unknown</database>
+	</source>
+	<size>
+		<width>640</width>
+		<height>480</height>
+		<depth>1</depth>
+	</size>
+	<segmented>0</segmented>
+	<object>
+		<name>can</name>
+		<pose>Unspecified</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>365</xmin>
+			<ymin>239</ymin>
+			<xmax>393</xmax>
+			<ymax>276</ymax>
+		</bndbox>
+	</object>
+</annotation>

--- a/fetch/change_xmlpath.py
+++ b/fetch/change_xmlpath.py
@@ -1,0 +1,29 @@
+import os
+import xml.etree.ElementTree as ET
+
+# Define the new path string
+new_path = 'path\\to\\folder'
+
+# Loop through all the XML files in the directory
+# Make sure in directory that contains annotations folder
+# Loop through all the directories and files within the annotations folder
+for dirpath, dirnames, filenames in os.walk('annotations'):
+    for filename in filenames:
+        if not filename.endswith('.xml'):
+            continue
+
+        # Load the XML file and find the path element
+        tree = ET.parse(os.path.join(dirpath, filename))
+        path_elem = tree.find('path')
+
+        # Get the filename without extension
+        filename_without_extension = os.path.splitext(filename)[0]
+
+        # Create the new path string
+        new_path_to_image = os.path.join(new_path, filename_without_extension + '.jpg')
+
+        # Replace the path with the new value
+        path_elem.text = new_path_to_image
+
+        # Save the modified XML file
+        tree.write(os.path.join(dirpath, filename))


### PR DESCRIPTION
The Python script called change_xmlpath.py is because when we crop all the images of the cans and save them as .xml files, it writes the full pathname of the file in the .xml file, but this doesnt work when all of us work together to crop it. So, the python script makes it so once everyone finishes cropping their portion, you can run it to change the base file path to a certain path based on the person's computer